### PR TITLE
fix(docker): add missing pull before docker run enacit-ansible

### DIFF
--- a/enac_cd_app/main.py
+++ b/enac_cd_app/main.py
@@ -27,6 +27,7 @@ def inject_apps():
     try:
         client = docker.from_env()
         client.login(username=GH_USERNAME, password=GH_PAT, registry="ghcr.io")
+        client.images.pull("ghcr.io/epfl-enac/enacit-ansible", tag="latest")
         output = client.containers.run(
             "ghcr.io/epfl-enac/enacit-ansible:latest",
             "announce-apps",


### PR DESCRIPTION
Needed so that when deploying new enac-cd-app, we always get the latest enacit-ansible.