### PR TITLE
feat(security): close Redis from the internet

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,9 +44,9 @@ services:
       - REDIS_ARGS=--requirepass ${REDIS_PASSWORD}
     volumes:
       - redis-data:/data
-    ports:
-      - 6379:6379
-      - 8001:8001
+    # ports:
+    #   - 6379:6379
+    #   - 8001:8001
 
 volumes:
   redis-data:


### PR DESCRIPTION
Simply do not open it.
Keep it commented so that it can be quickly enabled when doing dev on our laptop.