### PR TITLE
feat(CD): add success field to /job-status/

### DIFF
--- a/enac_cd_app/main.py
+++ b/enac_cd_app/main.py
@@ -143,7 +143,6 @@ async def get_job_status(payload: dict):
             "status": running_job.get("status"),
             "job_id": job_id,
             "output": running_job.get("output"),
-            "success": running_job.get("success"),
         }
     except Exception as e:
         return {"status": "error", "error": str(e)}

--- a/enac_cd_app/main.py
+++ b/enac_cd_app/main.py
@@ -143,6 +143,7 @@ async def get_job_status(payload: dict):
             "status": running_job.get("status"),
             "job_id": job_id,
             "output": running_job.get("output"),
+            "success": running_job.get("success"),
         }
     except Exception as e:
         return {"status": "error", "error": str(e)}

--- a/enac_cd_app/utils/redis_models.py
+++ b/enac_cd_app/utils/redis_models.py
@@ -23,6 +23,12 @@ class RunningStates(IntEnum):
     FINISHED = 3
 
 
+class RunningAppSuccess(IntEnum):
+    STILL_RUNNING = 0
+    SUCCESS = 1
+    FAILURE = 2
+
+
 class RunningAppDeployment(JsonModel):
     """
     Define a running app deployment
@@ -32,3 +38,4 @@ class RunningAppDeployment(JsonModel):
     status: RunningStates = Field(index=True)
     started_at: datetime.datetime
     output: str
+    success: RunningAppSuccess

--- a/enac_cd_app/utils/redis_models.py
+++ b/enac_cd_app/utils/redis_models.py
@@ -20,13 +20,8 @@ class DeployedApp(JsonModel):
 class RunningStates(IntEnum):
     STARTING = 1
     RUNNING = 2
-    FINISHED = 3
-
-
-class RunningAppSuccess(IntEnum):
-    STILL_RUNNING = 0
-    SUCCESS = 1
-    FAILURE = 2
+    SUCCESS = 3
+    ERROR = 4
 
 
 class RunningAppDeployment(JsonModel):
@@ -38,4 +33,3 @@ class RunningAppDeployment(JsonModel):
     status: RunningStates = Field(index=True)
     started_at: datetime.datetime
     output: str
-    success: RunningAppSuccess


### PR DESCRIPTION
FIX https://github.com/EPFL-ENAC/enac-cd-app/issues/5

In case of success, returns:
```json
{
    "job_id": "01GZY1VPYBYV4S28P7YHXSP0RE",
    "output": "",
    "status": "success"
}
```

In case of any error (unreachable/failure/...):
```json
{
    "job_id": "01GZY1HF06R50ZJRKK83R4QXA4",
    "output": "",
    "status": "error"
}
```