### PR TITLE
feat(my_docker.py): use env var ENAC_CD_APP_ROOT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 *.pyc
 .env
 .secret.env
+root/

--- a/README.md
+++ b/README.md
@@ -86,10 +86,24 @@ sequenceDiagram
 ```bash
 make generate-selfsigned-cert
 
-touch .env
-cat << EOF > .secret.env
-export REDIS_PASSWORD=secret
+cat << EOF > .env
+CD_ENV=test or prod
+MONITORING_IP=IP address authorized to monitor the app
+ENAC_CD_APP_ROOT=/_full_path_to_/enac-cd-app/root/
 EOF
+
+cat << EOF > .secret.env
+GH_USERNAME=GitHub username
+GH_PAT=<GitHub Personal Access Token>
+
+REDIS_PASSWORD=<secret>
+EOF
+
+touch root/.enacit-ansible_vault_password # to be filled
+
+# Add ssh key authorized to deploy apps
+touch root/.ssh/id_ed25519.pub # to be filled
+touch root/.ssh/id_ed25519 # to be filled
 
 make run
 ```

--- a/enac_cd_app/utils/my_docker.py
+++ b/enac_cd_app/utils/my_docker.py
@@ -12,6 +12,7 @@ CD_ENV = os.environ.get("CD_ENV")
 GH_USERNAME = os.environ.get("GH_USERNAME")
 GH_PAT = os.environ.get("GH_PAT")
 SELF_CONTAINER_CHECK_INTERVAL = 5  # seconds
+ENAC_CD_APP_ROOT = os.environ.get("ENAC_CD_APP_ROOT")
 
 logger_access = logging.getLogger("uvicorn.access")
 logger_error = logging.getLogger("uvicorn.error")
@@ -31,8 +32,8 @@ def inject_apps(job_id: str = None) -> None:
             "ghcr.io/epfl-enac/enacit-ansible:latest",
             "announce-apps",
             volumes={
-                "/opt/enac-cd-app/root/.ssh": {"bind": "/opt/root/.ssh", "mode": "ro"},
-                "/opt/enac-cd-app/root/.enacit-ansible_vault_password": {
+                f"{ENAC_CD_APP_ROOT}/.ssh": {"bind": "/opt/root/.ssh", "mode": "ro"},
+                f"{ENAC_CD_APP_ROOT}/.enacit-ansible_vault_password": {
                     "bind": "/root/.enacit-ansible_vault_password",
                     "mode": "rw",
                 },
@@ -71,11 +72,11 @@ def app_deploy(
             "ghcr.io/epfl-enac/enacit-ansible:latest",
             f"app-deploy {inventory} {job_id}",
             volumes={
-                "/opt/enac-cd-app/root/.ssh": {
+                f"{ENAC_CD_APP_ROOT}/.ssh": {
                     "bind": "/opt/root/.ssh",
                     "mode": "ro",
                 },
-                "/opt/enac-cd-app/root/.enacit-ansible_vault_password": {
+                f"{ENAC_CD_APP_ROOT}/.enacit-ansible_vault_password": {
                     "bind": "/root/.enacit-ansible_vault_password",
                     "mode": "rw",
                 },


### PR DESCRIPTION
Tested successfully locally :)

!! Remember to add ENAC_CD_APP_ROOT in .env for [test](https://github.com/EPFL-ENAC/enacit-ansible/blob/main/roles/app_deploy/host_files/enac-test-cd-runner.epfl.ch/.env) and [prod](https://github.com/EPFL-ENAC/enacit-ansible/blob/main/roles/app_deploy/host_files/enac-prod-cd-runner.epfl.ch/.env)